### PR TITLE
Introduce spf13/cobra with version sub-command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-## gup version**
+## honeycomb version**
 v0.y.z
 
 ## Description (About the problem)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ linters:
     - misspell
     - nakedret
     - noctx
-    - nolintlint
     - paralleltest
     - prealloc
     - rowserrcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
-## [](/compare/0c59a2334fbd...) (2024-05-17)
+## [](https://github.com/nao1215/honeycomb/compare/0c59a2334fbd...) (2024-05-18)
 
+* Bump github.com/google/go-cmp from 0.2.0 to 0.6.0 [#2](https://github.com/nao1215/honeycomb/pull/2) ([dependabot[bot]](https://github.com/apps/dependabot))
+* Add project template [#1](https://github.com/nao1215/honeycomb/pull/1) ([nao1215](https://github.com/nao1215))

--- a/cmd/honeycomb/root.go
+++ b/cmd/honeycomb/root.go
@@ -1,0 +1,26 @@
+// Package cmd define subcommands provided by the honeycomb command
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "honeycomb",
+		Short: `🐝 nostr client CLI application for cross-platform`,
+		Long:  `🐝 nostr client CLI application for cross-platform.`,
+	}
+	cmd.CompletionOptions.DisableDefaultCmd = true
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	cmd.AddCommand(newVersionCmd())
+	return cmd
+}
+
+// Execute run honeycomb process.
+func Execute() error {
+	rootCmd := newRootCmd()
+	return rootCmd.Execute()
+}

--- a/cmd/honeycomb/root_test.go
+++ b/cmd/honeycomb/root_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExecute(t *testing.T) { //nolint:paralleltest
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			args:    []string{""},
+			wantErr: false,
+		},
+		{
+			name:    "fail",
+			args:    []string{"no-exist-subcommand", "--no-exist-option"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests { //nolint:paralleltest
+		os.Args = tt.args
+		t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest
+			err := Execute()
+			gotErr := err != nil
+			if tt.wantErr != gotErr {
+				t.Errorf("expected error return %v, got %v: %v", tt.wantErr, gotErr, err)
+			}
+		})
+	}
+}
+
+func TestExecute_Version(t *testing.T) { //nolint:paralleltest
+	tests := []struct {
+		name   string
+		args   []string
+		stdout []string
+	}{
+		{
+			name:   "success",
+			args:   []string{"honeycomb", "version"},
+			stdout: []string{"honeycomb version  (MIT LICENSE)", ""},
+		},
+	}
+	for _, tt := range tests { //nolint:paralleltest
+		tt := tt
+
+		t.Run(tt.name, func(_ *testing.T) { //nolint:paralleltest
+			orgStdout := os.Stdout
+			orgStderr := os.Stderr
+			pr, pw, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = pw
+			os.Stderr = pw
+			os.Args = tt.args
+
+			if err = Execute(); err != nil {
+				t.Fatal(err)
+			}
+			if err := pw.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			os.Stdout = orgStdout
+			os.Stderr = orgStderr
+			buf := bytes.Buffer{}
+			if _, err = io.Copy(&buf, pr); err != nil {
+				t.Fatal(err)
+			}
+			defer pr.Close() //nolint
+
+			got := strings.Split(buf.String(), "\n")
+			if diff := cmp.Diff(tt.stdout, got); diff != "" {
+				t.Errorf("value is mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/honeycomb/version.go
+++ b/cmd/honeycomb/version.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/nao1215/honeycomb/version"
+	"github.com/spf13/cobra"
+)
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:               "version",
+		Short:             "Show honeycomb application version",
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		Run: func(cmd *cobra.Command, _ []string) {
+			cmd.Printf("honeycomb version %s (MIT LICENSE)\n", version.GetVersion())
+		},
+	}
+}

--- a/doc/img/cover-tree.svg
+++ b/doc/img/cover-tree.svg
@@ -7,40 +7,79 @@
 >
 
 <g>
-	<rect x="20.000000" y="20.000000" width="988.000000" height="600.000000" style="fill: rgb(64, 168, 88);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="20.000000" y="20.000000" width="988.000000" height="600.000000" style="fill: rgb(13, 130, 69);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
 	transform="translate(28.000000,35.600000) scale(1.000000)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">github.com/nao1215/honeycomb</text>
 		
 </g>
 
 
 <g>
-	<rect x="868.000000" y="41.600000" width="132.000000" height="570.400000" style="fill: rgb(165, 0, 38);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(876.000000,57.200000) scale(1.000000)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">main.go</text>
-		
-</g>
-
-
-<g>
-	<rect x="28.000000" y="41.600000" width="832.000000" height="570.400000" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="28.000000" y="41.600000" width="536.444444" height="570.400000" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
 	transform="translate(36.000000,57.200000) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">cmd/honeycomb</text>
+		
+</g>
+
+
+<g>
+	<rect x="572.444444" y="475.400000" width="427.555556" height="136.600000" style="fill: rgb(255, 255, 191);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(580.444444,491.000000) scale(1.000000)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">main.go</text>
+		
+</g>
+
+
+<g>
+	<rect x="572.444444" y="41.600000" width="427.555556" height="425.800000" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(580.444444,57.200000) scale(1.000000)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">version/version.go</text>
+		
+</g>
+
+
+<g>
+	<rect x="36.000000" y="63.200000" width="520.444444" height="431.040000" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(44.000000,78.800000) scale(1.000000)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">root.go</text>
+		
+</g>
+
+
+<g>
+	<rect x="36.000000" y="502.240000" width="520.444444" height="101.760000" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(44.000000,517.840000) scale(1.000000)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">version.go</text>
 		
 </g>
 

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,15 @@ go 1.20
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/wire v0.6.0
+	github.com/spf13/cobra v1.8.0
 )
 
 require (
 	github.com/google/subcommands v1.2.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/mod v0.14.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -5,8 +6,15 @@ github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/wire v0.6.0 h1:HBkoIh4BdSxoyo9PveV8giw7ZsaBOvzWKfcg/6MrVwI=
 github.com/google/wire v0.6.0/go.mod h1:F4QhpQ9EDIdJ1Mbop/NZBRB+5yrR6qg3BnctaoUk6NA=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -28,8 +36,9 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -60,3 +69,5 @@ golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58
 golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
 golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -3,8 +3,13 @@ package main
 
 import (
 	"fmt"
+	"os"
+
+	hc "github.com/nao1215/honeycomb/cmd/honeycomb"
 )
 
 func main() {
-	fmt.Println("Hello, world!")
+	if err := hc.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "honeycomb: %s\n", err.Error())
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,55 @@
+// Package main is the entry point of the honeycomb application.
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_main(t *testing.T) { //nolint:paralleltest
+	t.Run("show version", func(t *testing.T) { //nolint:paralleltest
+		orgStdout := os.Stdout
+		orgStderr := os.Stderr
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		os.Stdout = pw
+		os.Stderr = pw
+
+		defer func() {
+			os.Stdout = orgStdout
+			os.Stderr = orgStderr
+			pw.Close() //nolint
+			pr.Close() //nolint
+		}()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			os.Args = []string{"honeycomb", "version"}
+			main()
+			if err := pw.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		var buf bytes.Buffer
+		if _, err = io.Copy(&buf, pr); err != nil {
+			t.Fatal(err)
+		}
+		<-done
+
+		want := "honeycomb version (devel) (MIT LICENSE)"
+		got := strings.TrimSpace(buf.String())
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("value is mismatch (-want +got):\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command to display the version of the Honeycomb application.
  - Added a project template for easier setup.

- **Bug Fixes**
  - Updated `github.com/google/go-cmp` from version 0.2.0 to 0.6.0 for improved compatibility and performance.

- **Documentation**
  - Updated the bug report template to use "honeycomb version" instead of "gup version."

- **Tests**
  - Added tests for command execution and version output to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->